### PR TITLE
* clanglib-unix.cbp: Removed hard coded paths. (Thanks stahta01)

### DIFF
--- a/clanglib-unix.cbp
+++ b/clanglib-unix.cbp
@@ -2,13 +2,13 @@
 <CodeBlocks_project_file>
 	<FileVersion major="1" minor="6" />
 	<Project>
-		<Option title="clanglib (Unix)" />
+		<Option title="clanglib wx2.8.x (Unix)" />
 		<Option pch_mode="2" />
 		<Option default_target="ClangLib" />
 		<Option compiler="gcc" />
 		<Build>
-			<Target title="Release">
-				<Option output="Release/libclanglib" prefix_auto="0" extension_auto="1" />
+			<Target title="use_pch">
+				<Option output="use_pch/clanglib" prefix_auto="0" extension_auto="1" />
 				<Option object_output=".objs/plugins/clanglib" />
 				<Option type="3" />
 				<Option compiler="gcc" />
@@ -18,15 +18,17 @@
 				<Option projectCompilerOptionsRelation="2" />
 				<Compiler>
 					<Add option="-DBUILDING_PLUGIN" />
+					<Add option="-DCB_PRECOMP" />
 					<Add directory="." />
-					<Add directory="../codeblocks-1510/src/include" />
 				</Compiler>
 				<ExtraCommands>
 					<Add after="zip -j9 clanglib.zip resources/manifest.xml resources/ccsettings.xrc" />
+					<Add after="zip -j9 clanglib.cbplugin use_pch/clanglib.so clanglib.zip" />
+					<Mode after="always" />
 				</ExtraCommands>
 			</Target>
-			<Target title="Debug">
-				<Option output="Debug/libclanglib" prefix_auto="0" extension_auto="1" />
+			<Target title="no_pch">
+				<Option output="no_pch/libclanglib" prefix_auto="0" extension_auto="1" />
 				<Option object_output=".objs/plugins/clanglib" />
 				<Option type="3" />
 				<Option compiler="gcc" />
@@ -36,16 +38,18 @@
 				<Option projectCompilerOptionsRelation="2" />
 				<Compiler>
 					<Add option="-DBUILDING_PLUGIN" />
+					<Add option="-DNOPCH" />
 					<Add directory="." />
-					<Add directory="../codeblocks-1510/src/include" />
 				</Compiler>
 				<ExtraCommands>
 					<Add after="zip -j9 clanglib.zip resources/manifest.xml resources/ccsettings.xrc" />
+					<Add after="zip -j9 clanglib.cbplugin no_pch/clanglib.so clanglib.zip" />
+					<Mode after="always" />
 				</ExtraCommands>
 			</Target>
 		</Build>
 		<VirtualTargets>
-			<Add alias="All" targets="Release;" />
+			<Add alias="All" targets="use_pch;" />
 		</VirtualTargets>
 		<Compiler>
 			<Add option="-O3" />
@@ -53,28 +57,29 @@
 			<Add option="-Wall" />
 			<Add option="-std=c++0x" />
 			<Add option="-ansi" />
+			<Add option="-fPIC" />
 			<Add option="$(#CB_RELEASE_TYPE)" />
 			<Add option="`wx-config --version=2.8 --cflags`" />
 			<Add option="-I`llvm-config --includedir`" />
 			<Add option="-fmessage-length=0" />
 			<Add option="-fexceptions" />
 			<Add option="-Winvalid-pch" />
-			<Add option="-fPIC" />
 			<Add option="-pthread" />
+			<Add option="`pkg-config --cflags codeblocks`" />
 			<Add option="-DcbDEBUG" />
-			<Add option="-DCB_PRECOMP" />
-			<Add option="-DWX_PRECOMP" />
-			<Add directory="../codeblocks-16.01.release/src/include" />
-			<Add directory="../codeblocks-16.01.release/src/sdk/wxscintilla/include" />
 		</Compiler>
 		<Linker>
 			<Add option="`wx-config --libs`" />
 			<Add option="-L`llvm-config --libdir`" />
 			<Add option="-Wl,--no-undefined" />
+			<Add option="`pkg-config --libs codeblocks`" />
 			<Add library="codeblocks" />
 			<Add library="clang" />
-			<Add directory="/home/ydemuyte/codeblocks-16.01/lib" />
 		</Linker>
+		<ExtraCommands>
+			<Add before="echo libs: `pkg-config --libs codeblocks`" />
+			<Add before="echo cflags: `pkg-config --cflags codeblocks`" />
+		</ExtraCommands>
 		<Unit filename="README.md">
 			<Option target="&lt;{~None~}&gt;" />
 		</Unit>


### PR DESCRIPTION
And, changed to targets "use_pch" and "no_pch".
Where PCH means Precompiled Headers.
Also, added before and after steps.
And, removed lib prefix on so file.

I also, added the creation of clanglib.cbplugin.

Tim S.
